### PR TITLE
Added GetAll method to Storage

### DIFF
--- a/Runtime/Storage.cs
+++ b/Runtime/Storage.cs
@@ -22,16 +22,17 @@ namespace ToolBox.Loader
 
 		public static T Get<T>() where T : ScriptableObject, ILoadable
 		{
+			return GetAll<T>().FirstOrDefault();
+		}
+
+		public static IEnumerable<T> GetAll<T>() where T : ScriptableObject, ILoadable
+		{
 #if UNITY_EDITOR
 			if (!Application.isPlaying)
 				_assets = Resources.FindObjectsOfTypeAll<ScriptableObject>();
 #endif
 
-			for (int i = 0; i < _assets.Length; i++)
-				if (_assets[i] is T asset)
-					return asset;
-
-			return null;
+			return _assets.Where(a => a is T).Cast<T>();
 		}
 	}
 


### PR DESCRIPTION
I refactored a bit of code and added a `GetAll<T>` method to allow selecting of all the Scriptable objects of this type. This might be useful if you wanted to select all the scriptable object enemies or tiles ect. 